### PR TITLE
Featured DJs UI improvement

### DIFF
--- a/src/components/DJCard.tsx
+++ b/src/components/DJCard.tsx
@@ -4,7 +4,6 @@ import { Users, Heart, Share2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 
-// Interface for DJ object
 interface DJ {
   id: string;
   name: string;
@@ -18,7 +17,6 @@ interface DJ {
   updated_at?: string;
 }
 
-// Original direct props interface
 interface DirectDJCardProps {
   id: string;
   name: string;

--- a/src/components/DJCard.tsx
+++ b/src/components/DJCard.tsx
@@ -4,7 +4,22 @@ import { Users, Heart, Share2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 
-interface DJCardProps {
+// Interface for DJ object
+interface DJ {
+  id: string;
+  name: string;
+  genre: string;
+  image_url?: string;
+  followers?: number;
+  bio?: string;
+  soundcloud_url?: string;
+  wallet_address?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+// Original direct props interface
+interface DirectDJCardProps {
   id: string;
   name: string;
   imageUrl: string;
@@ -13,7 +28,25 @@ interface DJCardProps {
   featured?: boolean;
 }
 
-const DJCard = ({ id, name, imageUrl, followers, genre, featured = false }: DJCardProps) => {
+// Props that accept either a DJ object or direct props
+type DJCardProps = 
+  | DirectDJCardProps 
+  | { dj: DJ; featured?: boolean };
+
+// Helper to determine if props are direct or from a DJ object
+const isDirectProps = (props: DJCardProps): props is DirectDJCardProps => {
+  return 'id' in props && !('dj' in props);
+};
+
+const DJCard = (props: DJCardProps) => {
+  // Extract values based on prop type
+  const id = isDirectProps(props) ? props.id : props.dj.id;
+  const name = isDirectProps(props) ? props.name : props.dj.name;
+  const imageUrl = isDirectProps(props) ? props.imageUrl : (props.dj.image_url || '');
+  const followers = isDirectProps(props) ? props.followers : (props.dj.followers || 0);
+  const genre = isDirectProps(props) ? props.genre : props.dj.genre;
+  const featured = 'featured' in props ? props.featured : false;
+
   const [isHovered, setIsHovered] = useState(false);
   
   const formattedFollowers = followers >= 1000 

--- a/src/components/FeaturedDJs.tsx
+++ b/src/components/FeaturedDJs.tsx
@@ -115,7 +115,15 @@ const FeaturedDJs = () => {
       }
       
       if (data && data.length > 0) {
-        setFeaturedDjs(data);
+        // If we have fewer than 4 DJs from the database, fill in the remaining slots with mock DJs
+        if (data.length < 4) {
+          const numMockDjsNeeded = 4 - data.length;
+          const mockDjsToAdd = MOCK_FEATURED_DJS.slice(0, numMockDjsNeeded);
+          
+          setFeaturedDjs([...data, ...mockDjsToAdd]);
+        } else {
+          setFeaturedDjs(data);
+        }
       } else {
         console.log('No featured DJs found, using mock data');
         setFeaturedDjs(MOCK_FEATURED_DJS);


### PR DESCRIPTION
when the UI has real data, there might not be enough DJ users registered in order to fill out the 'Register DJ' section of the frontpage

BEFORE

<img width="1440" alt="Screenshot 2025-03-18 at 1 36 34 PM" src="https://github.com/user-attachments/assets/588287d0-b5ff-4c44-ad07-a24bd1e75f2a" />

AFTER
<img width="1440" alt="Screenshot 2025-03-18 at 1 36 45 PM" src="https://github.com/user-attachments/assets/43e54648-4007-4b2a-a3ca-8c66bdf92d67" />
